### PR TITLE
docs: add SOLID/KISS/DRY guidance and lint instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,13 +12,20 @@ This file provides instructions for AI agents contributing to the **beautiful** 
 - Add YAML frontmatter: `python3 improved_docx_converter.py input.docx output.md --frontmatter`
 - Split DOCX into chapters: `python3 improved_docx_converter.py input.docx --split-chapters`
 
-## Testing
+## Code Quality Principles
+- Follow SOLID to keep modules cohesive and extensible.
+- Keep implementations straightforward (KISS) and avoid over-engineering.
+- Eliminate repetition; prefer abstractions that embody DRY.
+- Review every change for clarity and maintainability before committing.
+
+## Testing and Linting
 - Tests cover both unit and integration behaviour under `tests/`.
-- Always run the full test suite before committing:
+- Always run the linter and full test suite before committing:
   ```bash
   python3 -m venv venv
   source venv/bin/activate
-  pip install -U pip python-docx pytest
+  pip install -U pip python-docx pytest flake8
+  flake8 --exclude=venv .
   python3 -m pytest tests/ -v
   ```
 


### PR DESCRIPTION
## Summary
- clarify code quality expectations with SOLID, KISS, and DRY principles
- add linter usage alongside test instructions

## Testing
- `flake8 --exclude=venv .` *(fails: many style issues in existing codebase)*
- `pytest tests/ -v`


------
https://chatgpt.com/codex/tasks/task_e_68b741640764832b9cffee921e6a8cd7