### PR TITLE
Pass chapter number to formatting fixes

### DIFF
--- a/formatting_fixes.py
+++ b/formatting_fixes.py
@@ -287,13 +287,14 @@ class MarkdownFormatter:
             4: 6,  # И так далее...
         }
     
-    def transform_document(self, markdown_text: str) -> str:
+    def transform_document(self, markdown_text: str, chapter_number: int = 1) -> str:
         """
         Полная трансформация документа из chapters формата в samples формат
-        
+
         Args:
             markdown_text: Исходный markdown из chapters
-            
+            chapter_number: Номер главы, используемый при восстановлении нумерации
+
         Returns:
             Преобразованный markdown в формате samples
         """
@@ -368,8 +369,8 @@ class MarkdownFormatter:
         
         # 3. Восстанавливаем нумерацию разделов
         if h2_sections:
-            # Определяем структуру для первой главы (предполагаем 2 раздела)
-            chapter_structure = {1: len(h2_sections)}
+            # Определяем структуру для текущей главы
+            chapter_structure = {chapter_number: len(h2_sections)}
             numbered_sections = restore_section_numbering(h2_sections, chapter_structure)
             
             # Заменяем в результате

--- a/improved_docx_converter.py
+++ b/improved_docx_converter.py
@@ -49,7 +49,7 @@ try:
 except ImportError:
     # Если модуль не найден, создаем заглушку
     class MarkdownFormatter:
-        def transform_document(self, text):
+        def transform_document(self, text, chapter_number=1):
             return text
 
 
@@ -188,7 +188,7 @@ class ImprovedDocxToMarkdownConverter:
         
         # Применяем исправления форматирования
         if hasattr(self, 'apply_formatting_fixes') and self.apply_formatting_fixes:
-            raw_markdown = self._post_process_formatting(raw_markdown)
+            raw_markdown = self._post_process_formatting(raw_markdown, chapter_number=1)
             
         return raw_markdown
     
@@ -943,7 +943,8 @@ class ImprovedDocxToMarkdownConverter:
         
         # Применяем исправления форматирования
         if self.apply_formatting_fixes:
-            raw_content = self._post_process_formatting(raw_content)
+            chapter_num = chapter['info']['number']
+            raw_content = self._post_process_formatting(raw_content, chapter_number=chapter_num)
             
         return raw_content
     
@@ -1004,18 +1005,19 @@ class ImprovedDocxToMarkdownConverter:
             
         self.markdown_lines.append('')
     
-    def _post_process_formatting(self, markdown_content: str) -> str:
+    def _post_process_formatting(self, markdown_content: str, chapter_number: int = 1) -> str:
         """
         Применяет исправления форматирования к результату конвертации
         
         Args:
             markdown_content: Исходный markdown контент
-            
+            chapter_number: Номер главы для восстановления нумерации
+
         Returns:
             Улучшенный markdown контент
         """
         formatter = MarkdownFormatter()
-        return formatter.transform_document(markdown_content)
+        return formatter.transform_document(markdown_content, chapter_number=chapter_number)
 
 
 def main():


### PR DESCRIPTION
## Summary
- allow `MarkdownFormatter.transform_document` to accept `chapter_number`
- forward chapter number from converter when applying formatting fixes

## Testing
- `python3 -m pytest tests/ -v`


------
https://chatgpt.com/codex/tasks/task_e_68b74134740c832ba7658b9c700434ac