### PR TITLE
Group semicolon-delimited paragraphs into lists

### DIFF
--- a/formatting_fixes.py
+++ b/formatting_fixes.py
@@ -299,8 +299,38 @@ class MarkdownFormatter:
         """
         # 1. Исправляем frontmatter
         result = fix_frontmatter_format(markdown_text)
-        
-        # 2. Разбиваем на секции для обработки
+
+        # 2. Собираем блоки абзацев, заканчивающихся ';' или '.',
+        #    без пустых строк между ними, и преобразуем их в списки
+        lines = result.split('\n')
+        preprocessed_lines = []
+        block_lines: List[str] = []
+
+        def flush_block(add_blank_line: bool = False) -> None:
+            nonlocal block_lines, preprocessed_lines
+            if block_lines:
+                block_text = '\n\n'.join(block_lines)
+                converted = convert_paragraphs_to_lists(block_text)
+                preprocessed_lines.extend(converted.split('\n'))
+                if add_blank_line:
+                    preprocessed_lines.append('')
+                block_lines = []
+
+        for line in lines:
+            stripped = line.strip()
+            if stripped == '':
+                flush_block()
+                preprocessed_lines.append('')
+            elif not stripped.startswith('-') and stripped.endswith((';', '.')):
+                block_lines.append(stripped)
+            else:
+                flush_block(add_blank_line=True)
+                preprocessed_lines.append(line)
+
+        flush_block()
+        result = '\n'.join(preprocessed_lines).strip()
+
+        # 3. Разбиваем на секции для обработки
         sections = result.split('\n\n')
         transformed_sections = []
         
@@ -366,7 +396,7 @@ class MarkdownFormatter:
             else:
                 transformed_sections.append(section)
         
-        # 3. Восстанавливаем нумерацию разделов
+        # 4. Восстанавливаем нумерацию разделов
         if h2_sections:
             # Определяем структуру для первой главы (предполагаем 2 раздела)
             chapter_structure = {1: len(h2_sections)}

--- a/tests/unit/test_paragraph_block_conversion.py
+++ b/tests/unit/test_paragraph_block_conversion.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Тестирование преобразования последовательных абзацев в список"""
+
+from formatting_fixes import MarkdownFormatter
+
+
+def test_paragraph_block_converted_to_list():
+    formatter = MarkdownFormatter()
+    input_text = "Первый пункт;\nВторой пункт;\nТретий пункт.\n\nДальше текст."
+    expected = "- Первый пункт;\n- Второй пункт;\n- Третий пункт.\n\nДальше текст."
+    result = formatter.transform_document(input_text)
+    assert result == expected
+


### PR DESCRIPTION
## Summary
- preprocess markdown to group consecutive paragraphs ending with `;` or `.` and convert them into bullet lists before section processing
- add unit test ensuring paragraph blocks are converted to lists

## Testing
- `python3 -m pytest tests/ -v`

------
https://chatgpt.com/codex/tasks/task_e_68b7413b5494832b8f5e20afac27535b