### PR TITLE
Support inline code formatting for services and filenames

### DIFF
--- a/formatting_fixes.py
+++ b/formatting_fixes.py
@@ -251,12 +251,15 @@ def convert_paragraphs_to_lists(text: str) -> str:
     if text.strip().startswith('- '):
         return text
     
-    # Разбиваем на абзацы
+    # Сначала пытаемся разбить по пустой строке
     paragraphs = [p.strip() for p in text.split('\n\n') if p.strip()]
-    
+
+    # Если это не дало нескольких элементов, пробуем разбивку по строкам
+    if len(paragraphs) < 2:
+        paragraphs = [p.strip() for p in text.split('\n') if p.strip()]
+
     # Проверяем что это последовательность элементов списка
     if len(paragraphs) >= 2:
-        # Все элементы должны заканчиваться на ; кроме последнего на .
         is_list = True
         for i, para in enumerate(paragraphs):
             if i < len(paragraphs) - 1:
@@ -267,14 +270,10 @@ def convert_paragraphs_to_lists(text: str) -> str:
                 if not para.endswith('.'):
                     is_list = False
                     break
-        
+
         if is_list:
-            # Преобразуем в список
-            result = []
-            for para in paragraphs:
-                result.append(f"- {para}")
-            return '\n'.join(result)
-    
+            return '\n'.join(f"- {para}" for para in paragraphs)
+
     return text
 
 def format_technical_components(text: str) -> str:
@@ -496,7 +495,8 @@ class MarkdownFormatter:
                 # Простая эвристика: первый H3 - это главный заголовок
                 is_main = len([s for s in transformed_sections if s.startswith('#')]) == 0
                 fixed_heading = fix_heading_levels(section, is_main)
-                all_headings.append(fixed_heading)
+                if fixed_heading.startswith(('##', '###', '####')):
+                    all_headings.append(fixed_heading)
                 transformed_sections.append(fixed_heading)
             elif section.startswith('##') or section.startswith('####'):
                 # Собираем ВСЕ заголовки для иерархической обработки

--- a/improved_docx_converter.py
+++ b/improved_docx_converter.py
@@ -408,10 +408,26 @@ class ImprovedDocxToMarkdownConverter:
             elif run.italic and text.strip():
                 if not text.startswith('*'):
                     text = f"*{text}*"
-                
+
             result.append(text)
-            
-        return ''.join(result)
+        formatted = ''.join(result)
+        return self._apply_special_formatting(formatted)
+
+    def _apply_special_formatting(self, text: str) -> str:
+        """Добавляет оформление для сервисов и имён файлов"""
+        # Имена файлов с расширениями оборачиваем в ``
+        text = re.sub(
+            r"(?<!`)(\b[\w.-]+\.(?:ya?ml|conf|ini|sh|py|txt)\b)(?!`)",
+            r"`\1`",
+            text,
+        )
+        # Названия сервисов после слова "сервис" также оборачиваем
+        text = re.sub(
+            r"(?i)(\b(?:сервис[а-я]*|service)\s+)([A-Za-z0-9_-]+)",
+            lambda m: f"{m.group(1)}`{m.group(2)}`",
+            text,
+        )
+        return text
     
     def _is_list_item(self, para) -> bool:
         """Проверка, является ли параграф элементом списка"""

--- a/tests/unit/test_special_inline_code.py
+++ b/tests/unit/test_special_inline_code.py
@@ -1,0 +1,35 @@
+import pytest
+from pathlib import Path
+from improved_docx_converter import ImprovedDocxToMarkdownConverter
+
+
+class FakeFont:
+    def __init__(self, name=None):
+        self.name = name
+
+
+class FakeRun:
+    def __init__(self, text):
+        self.text = text
+        self.bold = False
+        self.italic = False
+        self.font = FakeFont()
+
+
+class FakeParagraph:
+    def __init__(self, text):
+        self.text = text
+        self.runs = [FakeRun(text)]
+
+
+def test_service_and_filename_wrapped_with_backticks():
+    docx_path = Path(__file__).parent.parent.parent / "dev.docx"
+    converter = ImprovedDocxToMarkdownConverter(str(docx_path))
+    para = FakeParagraph(
+        "Для установки сервиса Traefik необходимо подготовить файл docker-compose.yaml со следующим содержанием:"
+    )
+    formatted = converter._format_inline_text(para)
+    assert (
+        formatted
+        == "Для установки сервиса `Traefik` необходимо подготовить файл `docker-compose.yaml` со следующим содержанием:"
+    )


### PR DESCRIPTION
## Summary
- wrap service names and filenames in backticks during conversion
- improve list detection and heading numbering to keep formatting intact
- add unit test for inline code formatting

## Testing
- `make lint`
- `python3 -m pytest tests/ -v`

------
https://chatgpt.com/codex/tasks/task_e_68b80016dbb0832bb559e6898d86008d