### PR TITLE
feat: add prompt builder module

### DIFF
--- a/src/doc2md/prompt_builder.py
+++ b/src/doc2md/prompt_builder.py
@@ -1,0 +1,43 @@
+"""Utilities for building prompts for the LLM."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import random
+from typing import Dict, List
+
+
+class PromptBuilder:
+    """Builds system and user prompts for chapter conversion."""
+
+    def __init__(
+        self, rules_path: str | Path, samples_dir: str | Path, num_examples: int = 2
+    ) -> None:
+        self.rules = Path(rules_path).read_text(encoding="utf-8")
+        self.examples = self._load_examples(samples_dir, num_examples)
+
+    def _load_examples(self, samples_dir: str | Path, num_examples: int) -> str:
+        sample_paths = sorted(Path(samples_dir).rglob("*.md"))
+        if not sample_paths:
+            return ""
+        k = min(num_examples, len(sample_paths))
+        chosen = random.sample(sample_paths, k=k)
+        contents: List[str] = []
+        for path in chosen:
+            contents.append(path.read_text(encoding="utf-8").strip())
+        return "\n\n".join(contents)
+
+    def build_for_chapter(self, chapter_html: str) -> List[Dict[str, str]]:
+        system_prompt = (
+            "You are an expert DOCX to Markdown converter. Follow all rules precisely.\n"
+            f"FORMATTING RULES:\n{self.rules}\n"
+            f"EXAMPLES:\n{self.examples}"
+        )
+        user_prompt = (
+            "Convert this chapter HTML to Markdown. Return EXACTLY two blocks: a JSON manifest, then the Markdown content.\n"
+            f"CHAPTER HTML:\n```html\n{chapter_html}\n```"
+        )
+        return [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_prompt},
+        ]

--- a/tests/test_prompt_builder.py
+++ b/tests/test_prompt_builder.py
@@ -1,0 +1,22 @@
+import random
+
+from doc2md.prompt_builder import PromptBuilder
+
+
+def test_build_for_chapter_includes_rules_examples_and_html(monkeypatch) -> None:
+    monkeypatch.setattr(random, "sample", lambda seq, k: list(seq)[:k])
+    builder = PromptBuilder("formatting_rules.md", "samples")
+    messages = builder.build_for_chapter("<h1>Chap</h1>")
+
+    assert len(messages) == 2
+    system = messages[0]
+    user = messages[1]
+
+    assert system["role"] == "system"
+    assert "FORMATTING RULES:" in system["content"]
+    assert "EXAMPLES:" in system["content"]
+    assert "# Общие сведения" in system["content"]
+
+    assert user["role"] == "user"
+    assert "CHAPTER HTML:" in user["content"]
+    assert "<h1>Chap</h1>" in user["content"]


### PR DESCRIPTION
## Summary
- add `PromptBuilder` class to build LLM prompts from formatting rules and sample markdown
- test that prompts include rules, examples, and chapter HTML

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bad26fa1d8832b80c0e3717d9aef7e