### PR TITLE
Add markdown validators and navigation utilities

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ beautifulsoup4 = "^4.12.3"
 lxml = "^5.2.1"
 httpx = "^0.28.1"
 jsonschema = "^4.25.1"
+python-frontmatter = "^1.0.0"
 
 [tool.poetry.group.dev.dependencies]
 black = "^24.4.2"

--- a/src/doc2md/navigation.py
+++ b/src/doc2md/navigation.py
@@ -1,0 +1,47 @@
+"""Navigation utilities for generated Markdown files."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import List, Dict
+
+import frontmatter
+
+
+def inject_navigation_and_create_toc(output_dir: str) -> None:
+    """Inject readPrev/readNext into Markdown files and create toc.json."""
+    files = sorted(f for f in os.listdir(output_dir) if f.endswith(".md"))
+    titles: Dict[str, str] = {}
+    for name in files:
+        path = os.path.join(output_dir, name)
+        with open(path, "r", encoding="utf-8") as f:
+            post = frontmatter.load(f)
+        titles[name] = post.get("title", "")
+
+    toc: List[Dict[str, str]] = []
+    for idx, name in enumerate(files):
+        path = os.path.join(output_dir, name)
+        with open(path, "r", encoding="utf-8") as f:
+            post = frontmatter.load(f)
+        if idx > 0:
+            prev = files[idx - 1]
+            post["readPrev"] = {
+                "to": f"/{os.path.splitext(prev)[0]}",
+                "label": titles[prev],
+            }
+        if idx < len(files) - 1:
+            nxt = files[idx + 1]
+            post["readNext"] = {
+                "to": f"/{os.path.splitext(nxt)[0]}",
+                "label": titles[nxt],
+            }
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(frontmatter.dumps(post))
+        toc.append({"title": titles[name], "to": f"/{os.path.splitext(name)[0]}"})
+
+    with open(os.path.join(output_dir, "toc.json"), "w", encoding="utf-8") as f:
+        json.dump(toc, f, ensure_ascii=False, indent=2)
+
+
+__all__ = ["inject_navigation_and_create_toc"]

--- a/src/doc2md/validators.py
+++ b/src/doc2md/validators.py
@@ -1,0 +1,69 @@
+"""Markdown validation utilities."""
+
+from __future__ import annotations
+
+import re
+from typing import List
+
+
+def validate_app_annotations(markdown: str) -> List[str]:
+    """Check that all ::AppAnnotation blocks are properly closed."""
+    warnings: List[str] = []
+    starts = [m.start() for m in re.finditer(r"::AppAnnotation", markdown)]
+    ends = [m.start() for m in re.finditer(r"^::\s*$", markdown, flags=re.MULTILINE)]
+    if len(starts) != len(ends):
+        warnings.append("Mismatched ::AppAnnotation blocks")
+    elif starts and any(s > e for s, e in zip(starts, ends)):
+        warnings.append("Incorrect ::AppAnnotation block ordering")
+    return warnings
+
+
+def validate_table_captions(markdown: str) -> List[str]:
+    """Ensure table captions follow '> Таблица N – Description' format."""
+    warnings: List[str] = []
+    for line in markdown.splitlines():
+        if line.startswith("> Таблица"):
+            if not re.match(r"^> Таблица \d+ – .+", line):
+                warnings.append(f"Invalid table caption: {line}")
+    return warnings
+
+
+def validate_component_list_punctuation(markdown: str) -> List[str]:
+    """Ensure component lists use ';' and '.' punctuation."""
+    warnings: List[str] = []
+    lines = markdown.splitlines()
+    i = 0
+    while i < len(lines):
+        if lines[i].startswith("- "):
+            start = i
+            while i < len(lines) and lines[i].startswith("- "):
+                i += 1
+            group = lines[start:i]
+            for j, item in enumerate(group):
+                text = item.rstrip()
+                if j < len(group) - 1:
+                    if not text.endswith(";"):
+                        warnings.append(f"List item should end with ';': {item}")
+                else:
+                    if not text.endswith("."):
+                        warnings.append(f"Last list item should end with '.': {item}")
+            continue
+        i += 1
+    return warnings
+
+
+def run_all_validators(markdown: str) -> List[str]:
+    """Run all validators and collect warnings."""
+    warnings = []
+    warnings.extend(validate_app_annotations(markdown))
+    warnings.extend(validate_table_captions(markdown))
+    warnings.extend(validate_component_list_punctuation(markdown))
+    return warnings
+
+
+__all__ = [
+    "validate_app_annotations",
+    "validate_table_captions",
+    "validate_component_list_punctuation",
+    "run_all_validators",
+]

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+import frontmatter
+
+from doc2md.navigation import inject_navigation_and_create_toc
+
+
+def create_md(path: Path, title: str) -> None:
+    content = f"---\ntitle: {title}\n---\n\n# {title}\n"
+    path.write_text(content, encoding="utf-8")
+
+
+def test_inject_navigation_and_create_toc(tmp_path: Path) -> None:
+    files = [("a.md", "First"), ("b.md", "Second"), ("c.md", "Third")]
+    for name, title in files:
+        create_md(tmp_path / name, title)
+
+    inject_navigation_and_create_toc(str(tmp_path))
+
+    a = frontmatter.load(tmp_path / "a.md")
+    b = frontmatter.load(tmp_path / "b.md")
+    c = frontmatter.load(tmp_path / "c.md")
+
+    assert "readPrev" not in a
+    assert a["readNext"]["to"] == "/b"
+
+    assert b["readPrev"]["label"] == "First"
+    assert b["readNext"]["label"] == "Third"
+
+    assert c["readPrev"]["to"] == "/b"
+    assert "readNext" not in c
+
+    toc_path = tmp_path / "toc.json"
+    assert toc_path.exists()
+    content = toc_path.read_text(encoding="utf-8")
+    assert "First" in content and "Third" in content

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,0 +1,35 @@
+from doc2md.validators import (
+    run_all_validators,
+    validate_app_annotations,
+    validate_component_list_punctuation,
+    validate_table_captions,
+)
+
+
+def test_validate_app_annotations() -> None:
+    md_good = "::AppAnnotation\ntext\n::\n"
+    md_bad = "::AppAnnotation\ntext\n"
+    assert validate_app_annotations(md_good) == []
+    assert "Mismatched" in validate_app_annotations(md_bad)[0]
+
+
+def test_validate_table_captions() -> None:
+    md_good = "> Таблица 1 – Описание\n"
+    md_bad = "> Таблица X - Описание\n"
+    assert validate_table_captions(md_good) == []
+    assert validate_table_captions(md_bad)
+
+
+def test_validate_component_list_punctuation() -> None:
+    md_good = "- один;\n- два.\n"
+    md_bad = "- один\n- два\n"
+    assert validate_component_list_punctuation(md_good) == []
+    warnings = validate_component_list_punctuation(md_bad)
+    assert any(";" in w for w in warnings)
+    assert any("." in w for w in warnings)
+
+
+def test_run_all_validators_combines() -> None:
+    md = "::AppAnnotation\ntext\n\n> Таблица X - Описание\n\n- item\n- last\n"
+    warnings = run_all_validators(md)
+    assert len(warnings) == 4


### PR DESCRIPTION
## Summary
- add validators for AppAnnotation blocks, table captions, and component list punctuation
- inject navigation links and generate toc.json
- include python-frontmatter dependency and comprehensive tests

## Testing
- `black --check src tests`
- `ruff check src tests`
- `mypy src`
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bad76ba054832bbce4057fec2f1d47