### PR TITLE
Finalize CLI and configuration

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,4 @@
 OPENROUTER_API_KEY="your_api_key_here"
+# Optional OpenRouter configuration
+OPENROUTER_API_URL="https://openrouter.ai/api/v1/chat/completions"
+OPENROUTER_MODEL="gpt-4o-mini"

--- a/README.md
+++ b/README.md
@@ -1,1 +1,59 @@
 # doc2md
+
+`doc2md` — инструмент командной строки для конвертации технической документации из
+формата DOCX в набор Markdown-файлов согласно внутреннему стандарту.
+
+## Установка
+
+1. Убедитесь, что установлены **Python 3.11+** и [Poetry](https://python-poetry.org/).
+2. Установите зависимости:
+
+   ```bash
+   poetry install
+   ```
+
+## Конфигурация
+
+API-ключ и параметры OpenRouter задаются в файле `.env` в корне репозитория:
+
+```env
+OPENROUTER_API_KEY="your_api_key_here"
+OPENROUTER_API_URL="https://openrouter.ai/api/v1/chat/completions"
+OPENROUTER_MODEL="gpt-4o-mini"
+```
+
+## Использование
+
+Основная команда — `run`:
+
+```bash
+poetry run doc2md run input.docx --out output_dir \
+  --model gpt-4o-mini --dry-run
+```
+
+Опции:
+
+- `--out` — директория для сохранения результатов (по умолчанию `output`).
+- `--model` — модель OpenRouter для форматирования.
+- `--dry-run` — выполнить только этап препроцессинга без обращения к LLM.
+- `--style-map` — путь к кастомному файлу стилей Mammoth.
+- `--rules-path` — путь к файлу правил форматирования.
+- `--samples-dir` — каталог с примерами форматирования.
+
+После успешного завершения в указанной директории появятся Markdown-файлы
+глав, а также `toc.json` с оглавлением.
+
+## Тесты
+
+Запуск линтеров и тестов:
+
+```bash
+ruff .
+black --check .
+mypy .
+pytest
+```
+
+## Лицензия
+
+Проект распространяется под лицензией MIT.

--- a/poetry.lock
+++ b/poetry.lock
@@ -665,6 +665,102 @@ files = [
 cli = ["click (>=5.0)"]
 
 [[package]]
+name = "python-frontmatter"
+version = "1.1.0"
+description = "Parse and manage posts with YAML (or other) frontmatter"
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {file = "python-frontmatter-1.1.0.tar.gz", hash = "sha256:7118d2bd56af9149625745c58c9b51fb67e8d1294a0c76796dafdc72c36e5f6d"},
+    {file = "python_frontmatter-1.1.0-py3-none-any.whl", hash = "sha256:335465556358d9d0e6c98bbeb69b1c969f2a4a21360587b9873bfc3b213407c1"},
+]
+
+[package.dependencies]
+PyYAML = "*"
+
+[package.extras]
+docs = ["sphinx"]
+test = ["mypy", "pyaml", "pytest", "toml", "types-PyYAML", "types-toml"]
+
+[[package]]
+name = "python-slugify"
+version = "1.2.1"
+description = "A Python Slugify application that handles Unicode"
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {file = "python-slugify-1.2.1.tar.gz", hash = "sha256:501182ec738cc8b743ae5c76c183f4427187ef016257f062b3fa594f60916e34"},
+]
+
+[package.dependencies]
+Unidecode = ">=0.04.16"
+
+[[package]]
+name = "pyyaml"
+version = "6.0.2"
+description = "YAML parser and emitter for Python"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "PyYAML-6.0.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0a9a2848a5b7feac301353437eb7d5957887edbf81d56e903999a75a3d743086"},
+    {file = "PyYAML-6.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:29717114e51c84ddfba879543fb232a6ed60086602313ca38cce623c1d62cfbf"},
+    {file = "PyYAML-6.0.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8824b5a04a04a047e72eea5cec3bc266db09e35de6bdfe34c9436ac5ee27d237"},
+    {file = "PyYAML-6.0.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7c36280e6fb8385e520936c3cb3b8042851904eba0e58d277dca80a5cfed590b"},
+    {file = "PyYAML-6.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ec031d5d2feb36d1d1a24380e4db6d43695f3748343d99434e6f5f9156aaa2ed"},
+    {file = "PyYAML-6.0.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:936d68689298c36b53b29f23c6dbb74de12b4ac12ca6cfe0e047bedceea56180"},
+    {file = "PyYAML-6.0.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:23502f431948090f597378482b4812b0caae32c22213aecf3b55325e049a6c68"},
+    {file = "PyYAML-6.0.2-cp310-cp310-win32.whl", hash = "sha256:2e99c6826ffa974fe6e27cdb5ed0021786b03fc98e5ee3c5bfe1fd5015f42b99"},
+    {file = "PyYAML-6.0.2-cp310-cp310-win_amd64.whl", hash = "sha256:a4d3091415f010369ae4ed1fc6b79def9416358877534caf6a0fdd2146c87a3e"},
+    {file = "PyYAML-6.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:cc1c1159b3d456576af7a3e4d1ba7e6924cb39de8f67111c735f6fc832082774"},
+    {file = "PyYAML-6.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1e2120ef853f59c7419231f3bf4e7021f1b936f6ebd222406c3b60212205d2ee"},
+    {file = "PyYAML-6.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5d225db5a45f21e78dd9358e58a98702a0302f2659a3c6cd320564b75b86f47c"},
+    {file = "PyYAML-6.0.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5ac9328ec4831237bec75defaf839f7d4564be1e6b25ac710bd1a96321cc8317"},
+    {file = "PyYAML-6.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3ad2a3decf9aaba3d29c8f537ac4b243e36bef957511b4766cb0057d32b0be85"},
+    {file = "PyYAML-6.0.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:ff3824dc5261f50c9b0dfb3be22b4567a6f938ccce4587b38952d85fd9e9afe4"},
+    {file = "PyYAML-6.0.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:797b4f722ffa07cc8d62053e4cff1486fa6dc094105d13fea7b1de7d8bf71c9e"},
+    {file = "PyYAML-6.0.2-cp311-cp311-win32.whl", hash = "sha256:11d8f3dd2b9c1207dcaf2ee0bbbfd5991f571186ec9cc78427ba5bd32afae4b5"},
+    {file = "PyYAML-6.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:e10ce637b18caea04431ce14fabcf5c64a1c61ec9c56b071a4b7ca131ca52d44"},
+    {file = "PyYAML-6.0.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:c70c95198c015b85feafc136515252a261a84561b7b1d51e3384e0655ddf25ab"},
+    {file = "PyYAML-6.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ce826d6ef20b1bc864f0a68340c8b3287705cae2f8b4b1d932177dcc76721725"},
+    {file = "PyYAML-6.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f71ea527786de97d1a0cc0eacd1defc0985dcf6b3f17bb77dcfc8c34bec4dc5"},
+    {file = "PyYAML-6.0.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9b22676e8097e9e22e36d6b7bda33190d0d400f345f23d4065d48f4ca7ae0425"},
+    {file = "PyYAML-6.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476"},
+    {file = "PyYAML-6.0.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:0833f8694549e586547b576dcfaba4a6b55b9e96098b36cdc7ebefe667dfed48"},
+    {file = "PyYAML-6.0.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8b9c7197f7cb2738065c481a0461e50ad02f18c78cd75775628afb4d7137fb3b"},
+    {file = "PyYAML-6.0.2-cp312-cp312-win32.whl", hash = "sha256:ef6107725bd54b262d6dedcc2af448a266975032bc85ef0172c5f059da6325b4"},
+    {file = "PyYAML-6.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:7e7401d0de89a9a855c839bc697c079a4af81cf878373abd7dc625847d25cbd8"},
+    {file = "PyYAML-6.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:efdca5630322a10774e8e98e1af481aad470dd62c3170801852d752aa7a783ba"},
+    {file = "PyYAML-6.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:50187695423ffe49e2deacb8cd10510bc361faac997de9efef88badc3bb9e2d1"},
+    {file = "PyYAML-6.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ffe8360bab4910ef1b9e87fb812d8bc0a308b0d0eef8c8f44e0254ab3b07133"},
+    {file = "PyYAML-6.0.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:17e311b6c678207928d649faa7cb0d7b4c26a0ba73d41e99c4fff6b6c3276484"},
+    {file = "PyYAML-6.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5"},
+    {file = "PyYAML-6.0.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:41e4e3953a79407c794916fa277a82531dd93aad34e29c2a514c2c0c5fe971cc"},
+    {file = "PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652"},
+    {file = "PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183"},
+    {file = "PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563"},
+    {file = "PyYAML-6.0.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:24471b829b3bf607e04e88d79542a9d48bb037c2267d7927a874e6c205ca7e9a"},
+    {file = "PyYAML-6.0.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d7fded462629cfa4b685c5416b949ebad6cec74af5e2d42905d41e257e0869f5"},
+    {file = "PyYAML-6.0.2-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d84a1718ee396f54f3a086ea0a66d8e552b2ab2017ef8b420e92edbc841c352d"},
+    {file = "PyYAML-6.0.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9056c1ecd25795207ad294bcf39f2db3d845767be0ea6e6a34d856f006006083"},
+    {file = "PyYAML-6.0.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:82d09873e40955485746739bcb8b4586983670466c23382c19cffecbf1fd8706"},
+    {file = "PyYAML-6.0.2-cp38-cp38-win32.whl", hash = "sha256:43fa96a3ca0d6b1812e01ced1044a003533c47f6ee8aca31724f78e93ccc089a"},
+    {file = "PyYAML-6.0.2-cp38-cp38-win_amd64.whl", hash = "sha256:01179a4a8559ab5de078078f37e5c1a30d76bb88519906844fd7bdea1b7729ff"},
+    {file = "PyYAML-6.0.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:688ba32a1cffef67fd2e9398a2efebaea461578b0923624778664cc1c914db5d"},
+    {file = "PyYAML-6.0.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a8786accb172bd8afb8be14490a16625cbc387036876ab6ba70912730faf8e1f"},
+    {file = "PyYAML-6.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d8e03406cac8513435335dbab54c0d385e4a49e4945d2909a581c83647ca0290"},
+    {file = "PyYAML-6.0.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f753120cb8181e736c57ef7636e83f31b9c0d1722c516f7e86cf15b7aa57ff12"},
+    {file = "PyYAML-6.0.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3b1fdb9dc17f5a7677423d508ab4f243a726dea51fa5e70992e59a7411c89d19"},
+    {file = "PyYAML-6.0.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:0b69e4ce7a131fe56b7e4d770c67429700908fc0752af059838b1cfb41960e4e"},
+    {file = "PyYAML-6.0.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a9f8c2e67970f13b16084e04f134610fd1d374bf477b17ec1599185cf611d725"},
+    {file = "PyYAML-6.0.2-cp39-cp39-win32.whl", hash = "sha256:6395c297d42274772abc367baaa79683958044e5d3835486c16da75d2a694631"},
+    {file = "PyYAML-6.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:39693e1f8320ae4f43943590b49779ffb98acb81f788220ea932a6b6c51004d8"},
+    {file = "pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e"},
+]
+
+[[package]]
 name = "referencing"
 version = "0.36.2"
 description = "JSON Referencing + Python"
@@ -959,7 +1055,19 @@ files = [
     {file = "typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"},
 ]
 
+[[package]]
+name = "unidecode"
+version = "1.4.0"
+description = "ASCII transliterations of Unicode text"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "Unidecode-1.4.0-py3-none-any.whl", hash = "sha256:c3c7606c27503ad8d501270406e345ddb480a7b5f38827eafe4fa82a137f0021"},
+    {file = "Unidecode-1.4.0.tar.gz", hash = "sha256:ce35985008338b676573023acc382d62c264f307c8f7963733405add37ea2b23"},
+]
+
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "00130d9c1b0e884f133bcf57942664b6b9d16fad64c0a73da457d40c18d70770"
+content-hash = "2d1dcfe247068dafaa577cce5ed8110c5c06fc004537a3e10436fc3189fcc908"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ lxml = "^5.2.1"
 httpx = "^0.28.1"
 jsonschema = "^4.25.1"
 python-frontmatter = "^1.0.0"
+python-slugify = "1.2.1"
 
 [tool.poetry.group.dev.dependencies]
 black = "^24.4.2"

--- a/src/doc2md/cli.py
+++ b/src/doc2md/cli.py
@@ -3,8 +3,12 @@ from pathlib import Path
 
 import typer
 from rich.console import Console
+from rich.progress import Progress
+from slugify import slugify
 
-from . import preprocess, splitter
+from . import navigation, postprocess, preprocess, prompt_builder, splitter, validators
+from .config import DEFAULT_MODEL
+from .llm_client import OpenRouterClient
 
 logging.basicConfig(level=logging.INFO)
 
@@ -15,8 +19,6 @@ console = Console()
 @app.callback()
 def main() -> None:
     """Main entry point for the CLI."""
-    # This function allows adding subcommands like `run`.
-    # It does not execute any logic by itself.
     pass
 
 
@@ -25,6 +27,24 @@ def run(
     docx_path: str = typer.Argument(..., help="Путь к входному DOCX файлу."),
     output_dir: str = typer.Option(
         "output", "--out", "-o", help="Директория для сохранения Markdown файлов."
+    ),
+    style_map: Path = typer.Option(
+        Path(__file__).with_name("mammoth_style_map.map"),
+        help="Путь к файлу style-map для Mammoth.",
+    ),
+    rules_path: Path = typer.Option(
+        Path(__file__).resolve().parents[2] / "formatting_rules.md",
+        help="Путь к правилам форматирования.",
+    ),
+    samples_dir: Path = typer.Option(
+        Path(__file__).resolve().parents[2] / "samples",
+        help="Каталог с примерами форматирования.",
+    ),
+    model: str = typer.Option(
+        DEFAULT_MODEL, "--model", help="Имя модели OpenRouter для форматирования."
+    ),
+    dry_run: bool = typer.Option(
+        False, "--dry-run/--no-dry-run", help="Запуск без обращения к LLM."
     ),
 ) -> None:
     """Run the conversion pipeline."""
@@ -36,15 +56,36 @@ def run(
     images_dir = output_path / "images"
     preprocess.extract_images(docx_path, str(images_dir))
 
-    style_map_path = Path(__file__).with_name("mammoth_style_map.map")
-    html = preprocess.convert_docx_to_html(docx_path, str(style_map_path))
+    html = preprocess.convert_docx_to_html(docx_path, str(style_map))
     chapters = splitter.split_html_by_h1(html)
 
-    temp_dir = output_path / "html"
-    temp_dir.mkdir(parents=True, exist_ok=True)
-    for idx, chapter in enumerate(chapters, start=1):
-        (temp_dir / f"chapter_{idx}.html").write_text(chapter, encoding="utf-8")
+    if dry_run:
+        temp_dir = output_path / "html"
+        temp_dir.mkdir(parents=True, exist_ok=True)
+        for idx, chapter in enumerate(chapters, start=1):
+            (temp_dir / f"chapter_{idx}.html").write_text(chapter, encoding="utf-8")
+        console.print(
+            f"[yellow]Dry run completed. HTML chapters saved to {temp_dir}.[/]"
+        )
+        return
 
+    doc_slug = slugify(Path(docx_path).stem)
+    builder = prompt_builder.PromptBuilder(rules_path, samples_dir)
+    client = OpenRouterClient(builder, model=model)
+
+    with Progress() as progress:
+        task = progress.add_task("Formatting chapters", total=len(chapters))
+        for idx, chapter in enumerate(chapters, start=1):
+            manifest, md = client.format_chapter(chapter)
+            processed = postprocess.PostProcessor(md, idx, doc_slug).run()
+            warnings = validators.run_all_validators(processed)
+            for w in warnings:
+                logging.warning(w)
+            file_path = output_path / manifest["filename"]
+            file_path.write_text(processed, encoding="utf-8")
+            progress.advance(task)
+
+    navigation.inject_navigation_and_create_toc(str(output_path))
     console.print(f"[bold green]Конвертация завершена. Результаты в:[/] {output_dir}")
 
 

--- a/src/doc2md/config.py
+++ b/src/doc2md/config.py
@@ -7,4 +7,10 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-API_KEY = os.getenv("OPENROUTER_API_KEY")
+API_KEY = os.getenv("OPENROUTER_API_KEY", "")
+API_URL = os.getenv(
+    "OPENROUTER_API_URL", "https://openrouter.ai/api/v1/chat/completions"
+)
+DEFAULT_MODEL = os.getenv("OPENROUTER_MODEL", "gpt-4o-mini")
+
+__all__ = ["API_KEY", "API_URL", "DEFAULT_MODEL"]

--- a/src/doc2md/llm_client.py
+++ b/src/doc2md/llm_client.py
@@ -5,44 +5,43 @@ from __future__ import annotations
 import json
 import re
 import time
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Protocol, Tuple
 
 import httpx
 from jsonschema import validate
 
-from .config import API_KEY
+from .config import API_KEY, API_URL, DEFAULT_MODEL
 
 # The schema is optional during early development stages. Tests may patch this
 # constant to supply a concrete schema.
 CHAPTER_MANIFEST_SCHEMA: Dict[str, Any] = {}
 
 
-class PromptBuilderProtocol:
-    """Protocol-like interface for prompt builders."""
+class PromptBuilderProtocol(Protocol):
+    """Interface for prompt builders."""
 
     def build_for_chapter(
         self, chapter_html: str
-    ) -> List[Dict[str, str]]:  # pragma: no cover - interface
-        raise NotImplementedError
+    ) -> List[Dict[str, str]]: ...  # pragma: no cover - interface
 
 
 class OpenRouterClient:
     """HTTP client wrapper with basic retry and response parsing."""
-
-    api_url = "https://openrouter.ai/api/v1/chat/completions"
 
     def __init__(
         self,
         prompt_builder: PromptBuilderProtocol,
         api_key: str | None = None,
         *,
-        model: str = "gpt-4o-mini",
+        model: str | None = None,
+        api_url: str | None = None,
         max_retries: int = 5,
         client: httpx.Client | None = None,
     ) -> None:
         self.prompt_builder = prompt_builder
         self.api_key = api_key or API_KEY
-        self.model = model
+        self.model = model or DEFAULT_MODEL
+        self.api_url = api_url or API_URL
         self.max_retries = max_retries
         self._client = client or httpx.Client()
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,7 +5,7 @@ from doc2md.cli import app
 runner = CliRunner()
 
 
-def test_run_shows_conversion_messages(monkeypatch, tmp_path) -> None:
+def _patch_preprocess(monkeypatch) -> None:
     def fake_convert(docx_path: str, style_map_path: str) -> str:
         return "<h1>Chap</h1><p>Body</p>"
 
@@ -19,7 +19,71 @@ def test_run_shows_conversion_messages(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr("doc2md.preprocess.extract_images", fake_extract)
     monkeypatch.setattr("doc2md.splitter.split_html_by_h1", fake_split)
 
-    result = runner.invoke(app, ["run", "input.docx", "--out", str(tmp_path)])
+
+def test_run_dry_run_skips_llm(monkeypatch, tmp_path) -> None:
+    _patch_preprocess(monkeypatch)
+
+    called = {"client": False}
+
+    class DummyClient:
+        def __init__(self, *a, **k):
+            called["client"] = True
+
+    monkeypatch.setattr("doc2md.cli.OpenRouterClient", DummyClient)
+
+    result = runner.invoke(
+        app, ["run", "input.docx", "--out", str(tmp_path), "--dry-run"]
+    )
+
     assert result.exit_code == 0
-    assert "Запуск конвертации для файла:" in result.stdout
-    assert "Конвертация завершена. Результаты в:" in result.stdout
+    assert "Dry run completed" in result.stdout
+    assert not called["client"]
+
+
+def test_run_passes_model_option(monkeypatch, tmp_path) -> None:
+    _patch_preprocess(monkeypatch)
+
+    class FakeBuilder:
+        def build_for_chapter(self, html: str):
+            return []
+
+    class DummyPost:
+        def __init__(self, md: str, idx: int, slug: str) -> None:
+            self.md = md
+
+        def run(self) -> str:
+            return self.md
+
+    captured = {}
+
+    class DummyClient:
+        def __init__(self, builder, api_key=None, *, model, **kw):
+            captured["model"] = model
+
+        def format_chapter(self, chapter_html: str):
+            return (
+                {
+                    "chapter_number": 1,
+                    "title": "Chap",
+                    "filename": "chap.md",
+                    "slug": "chap",
+                },
+                "## Heading\nBody",
+            )
+
+    monkeypatch.setattr(
+        "doc2md.prompt_builder.PromptBuilder", lambda *a, **k: FakeBuilder()
+    )
+    monkeypatch.setattr("doc2md.cli.OpenRouterClient", DummyClient)
+    monkeypatch.setattr("doc2md.postprocess.PostProcessor", DummyPost)
+    monkeypatch.setattr(
+        "doc2md.navigation.inject_navigation_and_create_toc", lambda *a, **k: None
+    )
+    monkeypatch.setattr("doc2md.validators.run_all_validators", lambda text: [])
+
+    result = runner.invoke(
+        app, ["run", "input.docx", "--out", str(tmp_path), "--model", "test-model"]
+    )
+
+    assert result.exit_code == 0
+    assert captured["model"] == "test-model"


### PR DESCRIPTION
## Summary
- expand CLI with model selection, path options and a dry-run mode
- centralize OpenRouter settings in config and `.env`
- document setup and usage in the README; add tests for CLI options

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68badbc8c308832b85c4a21d15bcf108