### PR TITLE
chore: update slugify dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -685,17 +685,21 @@ test = ["mypy", "pyaml", "pytest", "toml", "types-PyYAML", "types-toml"]
 
 [[package]]
 name = "python-slugify"
-version = "1.2.1"
-description = "A Python Slugify application that handles Unicode"
+version = "8.0.4"
+description = "A Python slugify application that also handles Unicode"
 optional = false
-python-versions = "*"
+python-versions = ">=3.7"
 groups = ["main"]
 files = [
-    {file = "python-slugify-1.2.1.tar.gz", hash = "sha256:501182ec738cc8b743ae5c76c183f4427187ef016257f062b3fa594f60916e34"},
+    {file = "python-slugify-8.0.4.tar.gz", hash = "sha256:59202371d1d05b54a9e7720c5e038f928f45daaffe41dd10822f3907b937c856"},
+    {file = "python_slugify-8.0.4-py2.py3-none-any.whl", hash = "sha256:276540b79961052b66b7d116620b36518847f52d5fd9e3a70164fc8c50faa6b8"},
 ]
 
 [package.dependencies]
-Unidecode = ">=0.04.16"
+text-unidecode = ">=1.3"
+
+[package.extras]
+unidecode = ["Unidecode (>=1.1.1)"]
 
 [[package]]
 name = "pyyaml"
@@ -1026,6 +1030,18 @@ files = [
 ]
 
 [[package]]
+name = "text-unidecode"
+version = "1.3"
+description = "The most basic Text::Unidecode port"
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {file = "text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93"},
+    {file = "text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8"},
+]
+
+[[package]]
 name = "typer"
 version = "0.12.5"
 description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
@@ -1055,19 +1071,7 @@ files = [
     {file = "typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"},
 ]
 
-[[package]]
-name = "unidecode"
-version = "1.4.0"
-description = "ASCII transliterations of Unicode text"
-optional = false
-python-versions = ">=3.7"
-groups = ["main"]
-files = [
-    {file = "Unidecode-1.4.0-py3-none-any.whl", hash = "sha256:c3c7606c27503ad8d501270406e345ddb480a7b5f38827eafe4fa82a137f0021"},
-    {file = "Unidecode-1.4.0.tar.gz", hash = "sha256:ce35985008338b676573023acc382d62c264f307c8f7963733405add37ea2b23"},
-]
-
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "2d1dcfe247068dafaa577cce5ed8110c5c06fc004537a3e10436fc3189fcc908"
+content-hash = "a712a44329885d93e708adf438ef7b27c3d6bb6920ae519adfa04b81f310fe92"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ lxml = "^5.2.1"
 httpx = "^0.28.1"
 jsonschema = "^4.25.1"
 python-frontmatter = "^1.0.0"
-python-slugify = "1.2.1"
+python-slugify = "^8.0.4"
 
 [tool.poetry.group.dev.dependencies]
 black = "^24.4.2"


### PR DESCRIPTION
## Summary
- update python-slugify to 8.0.4 to eliminate Python 3.12 escape sequence warnings
- refresh lockfile and include text-unidecode dependency

## Testing
- `poetry run ruff check .`
- `poetry run black --check .`
- `poetry run mypy .`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bae12da2a8832bb531a2e33eaa4e28