### PR TITLE
Limit LLM formatting to fourth chapter and harden response parsing

### DIFF
--- a/src/doc2md/cli.py
+++ b/src/doc2md/cli.py
@@ -61,10 +61,16 @@ def run(
     html = preprocess.remove_table_of_contents(html)
     chapters = splitter.split_html_by_h1(html)
 
+    # Temporary fix: only send the 4th chapter to the model
+    if len(chapters) >= 4:
+        chapters = [chapters[3]]
+    else:
+        chapters = []
+
     if dry_run:
         temp_dir = output_path / "html"
         temp_dir.mkdir(parents=True, exist_ok=True)
-        
+
         if chapters:
             for idx, chapter in enumerate(chapters, start=1):
                 (temp_dir / f"chapter_{idx}.html").write_text(chapter, encoding="utf-8")

--- a/src/doc2md/llm_client.py
+++ b/src/doc2md/llm_client.py
@@ -73,7 +73,13 @@ class OpenRouterClient:
                 delay *= 2
                 continue
             response.raise_for_status()
-            content = response.json()["choices"][0]["message"]["content"]
+            if "application/json" not in response.headers.get("Content-Type", ""):
+                raise ValueError("Unexpected content type from OpenRouter")
+            try:
+                data = response.json()
+            except json.JSONDecodeError as exc:
+                raise ValueError("Invalid JSON response from OpenRouter") from exc
+            content = data["choices"][0]["message"]["content"]
             json_match = re.search(r"```json\n(.*?)\n```", content, re.DOTALL)
             md_match = re.search(r"```markdown\n(.*?)\n```", content, re.DOTALL)
             if not json_match or not md_match:


### PR DESCRIPTION
## Summary
- Process only the fourth chapter when running `doc2md` for now
- Guard LLM client against non-JSON replies from OpenRouter

## Testing
- `poetry run ruff check src/doc2md/cli.py src/doc2md/llm_client.py`
- `poetry run black --check src/doc2md/cli.py src/doc2md/llm_client.py`
- `poetry run mypy src/doc2md/cli.py src/doc2md/llm_client.py --follow-imports=skip`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb1108a920832b80b4367da01434db